### PR TITLE
Adds support for bank switching on Genesis/MD carts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,10 +94,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
-/Python/Super Street Fighter II - The New Challengers (U) \[c\]\[!\].bin
-/Python/compare.jpg
-/Python/notes.txt
-/Python/sf2notes.txt
-/Python/sftest.bin
-/Python/streetpce/Street2.pce
-/Python/streetpceorig/Street Fighter II Champion Edition (J).pce
+

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,10 @@ ENV/
 
 # Rope project settings
 .ropeproject
+/Python/Super Street Fighter II - The New Challengers (U) \[c\]\[!\].bin
+/Python/compare.jpg
+/Python/notes.txt
+/Python/sf2notes.txt
+/Python/sftest.bin
+/Python/streetpce/Street2.pce
+/Python/streetpceorig/Street Fighter II Champion Edition (J).pce

--- a/Examples/Interface/Interface.ino
+++ b/Examples/Interface/Interface.ino
@@ -772,8 +772,9 @@ void readWordBlock()
 {
     char *arg;
     bool sramRead = false;
-    uint32_t address = 0;
-    uint16_t blockSize = 0, i;
+    bool latchBankRead = false;
+    uint32_t address = 0, addrOffset = 0;
+    uint16_t blockSize = 0, i, restBlockSize = 0;
     uint16_t data;
 
     //get the address in the next argument
@@ -795,6 +796,22 @@ void readWordBlock()
                 break;
             default:
                 break;
+        }
+    }
+
+    if( address + blockSize > 0x3FFFFF)
+    {
+        latchBankRead = true;
+        restBlockSize = blockSize;
+        if(address < 0x3FFFFF)
+        {
+            blockSize = 0x3FFFFF - address;
+            restBlockSize -= blockSize;
+        }
+        else
+        {
+            addrOffset = address - 0x3FFFFF;
+            blockSize = 0;
         }
     }
     
@@ -823,8 +840,27 @@ void readWordBlock()
             Serial.write((char)(data>>8));
         }
     }
-    
-    
+
+    if( latchBankRead )
+    {
+        umd.writeByteTimeFull( (uint32_t)0xA130FD, 0x08 ); // map bank 8 to 0x300000 - 0x37FFFF
+        umd.writeByteTimeFull( (uint32_t)0xA130FF, 0x09 ); // map bank 9 to 0x380000 - 0x3FFFFF
+
+        address = 0x300002 + addrOffset; // TODO: Should start at 0x300000 BUG
+
+        //read the rest of the words from bank switched block, output is little endian
+        for( i = 0; i < restBlockSize; i += 2 )
+        {
+            data = umd.readWord(address);
+            address += 2;
+            Serial.write((char)(data));
+            Serial.write((char)(data>>8));
+        }
+
+        umd.writeByteTimeFull( (uint32_t)0xA130FD, 0x06 ); // return banks to original state
+        umd.writeByteTimeFull( (uint32_t)0xA130FF, 0x07 ); // return banks to original state
+    }
+
     digitalWrite(umd.nLED, HIGH);
 }
 

--- a/Examples/Interface/Interface.ino
+++ b/Examples/Interface/Interface.ino
@@ -799,18 +799,18 @@ void readWordBlock()
         }
     }
 
-    if( address + blockSize > 0x3FFFFF)
+    if( address + blockSize >= 0x400000)
     {
         latchBankRead = true;
         restBlockSize = blockSize;
-        if(address < 0x3FFFFF)
+        if(address < 0x400000)
         {
-            blockSize = 0x3FFFFF - address;
+            blockSize = 0x400000 - address;
             restBlockSize -= blockSize;
         }
         else
         {
-            addrOffset = address - 0x3FFFFF;
+            addrOffset = address - 0x400000;
             blockSize = 0;
         }
     }
@@ -846,7 +846,7 @@ void readWordBlock()
         umd.writeByteTimeFull( (uint32_t)0xA130FD, 0x08 ); // map bank 8 to 0x300000 - 0x37FFFF
         umd.writeByteTimeFull( (uint32_t)0xA130FF, 0x09 ); // map bank 9 to 0x380000 - 0x3FFFFF
 
-        address = 0x300002 + addrOffset; // TODO: Should start at 0x300000 BUG
+        address = 0x300000 + addrOffset; // TODO: Should start at 0x300000 BUG
 
         //read the rest of the words from bank switched block, output is little endian
         for( i = 0; i < restBlockSize; i += 2 )

--- a/Python/hardware.py
+++ b/Python/hardware.py
@@ -522,8 +522,15 @@ class umd:
                     else:
                         sizeOfRead = (endAddress - address)
                     
-                    cmd = "{0} {1} {2}\r\n".format(readCmd, address, sizeOfRead)
-                                            
+                    if( target == "byte" or target == "word" ):
+                        cmd = "{0} {1}\r\n".format(readCmd, address)
+                    elif( target == "sbyte" or target == "sword" ):
+                        cmd = "{0} {1} s\r\n".format(readCmd, address)
+                    elif( target == "save" ):
+                        cmd = "{0} {1} {2} s\r\n".format(readCmd, address, sizeOfRead)
+                    else:
+                        cmd = "{0} {1} {2}\r\n".format(readCmd, address, sizeOfRead)
+                                                            
                     # send command to Teensy, read response    
                     self.serialPort.write(bytes(cmd,"utf-8"))
                     response = self.serialPort.read(sizeOfRead)

--- a/umd.cpp
+++ b/umd.cpp
@@ -668,6 +668,31 @@ void umd::writeByteTime(uint16_t address, uint8_t data)
 }
 
 /*******************************************************************//**
+ * The writeByteTimeFull function strobes a byte into nTIME region
+ * while enabling the rest of the regular signals
+ * 
+ * \warning upper 8 address bits (23..16) are not modified
+ **********************************************************************/
+void umd::writeByteTimeFull(uint32_t address, uint8_t data)
+{
+    _latchAddress(address);
+    _setDatabusOutput();
+
+    //put byte on bus
+    DATAOUTL = data;
+    
+    
+    // write to the bus
+    digitalWrite(GEN_nLWR, LOW);
+    digitalWrite(GEN_nTIME, LOW);
+    delayMicroseconds(1);
+    digitalWrite(GEN_nTIME, HIGH);
+    digitalWrite(GEN_nLWR, HIGH);
+ 
+    _setDatabusInput();
+}
+
+/*******************************************************************//**
  * The writeByte function strobes a byte into the cartridge at a 16bit
  * address. The upper 8 address bits (23..16) are not modified
  * by this function so this can be used to perform quicker successive

--- a/umd.h
+++ b/umd.h
@@ -180,6 +180,14 @@ class umd
         void writeByteTime(uint16_t address, uint8_t data);
         
         /*******************************************************************//**
+         * \brief Write a byte to the nTIME region on genesis with full signals
+         * \param address 16bit address
+         * \param data byte
+         * \return void
+         **********************************************************************/
+        void writeByteTimeFull(uint32_t address, uint8_t data);
+        
+        /*******************************************************************//**
          * \brief Write a byte to a 16bit address in the nTIME range (Genesis only)
          * \param address 16bit address
          * \param data byte


### PR DESCRIPTION
I needed to create a new function since GEN_nLWR line needed to be set for the GEN_nTIME to be recognized by the cartridge. 

I opted for a new function as not to break current functionality. Would need to check if both functions can be merged for "save" dumping.

Also added the needed commands to the file saving of save dumps on the python script.