### PR TITLE
Unified Time function and PC engine  SFII mapper support

### DIFF
--- a/Examples/Interface/Interface.ino
+++ b/Examples/Interface/Interface.ino
@@ -843,8 +843,8 @@ void readWordBlock()
 
     if( latchBankRead )
     {
-        umd.writeByteTimeFull( (uint32_t)0xA130FD, 0x08 ); // map bank 8 to 0x300000 - 0x37FFFF
-        umd.writeByteTimeFull( (uint32_t)0xA130FF, 0x09 ); // map bank 9 to 0x380000 - 0x3FFFFF
+        umd.writeByteTime(0xA130FD, 0x08 ); // map bank 8 to 0x300000 - 0x37FFFF
+        umd.writeByteTime(0xA130FF, 0x09 ); // map bank 9 to 0x380000 - 0x3FFFFF
 
         address = 0x300000 + addrOffset; // TODO: Should start at 0x300000 BUG
 
@@ -857,8 +857,8 @@ void readWordBlock()
             Serial.write((char)(data>>8));
         }
 
-        umd.writeByteTimeFull( (uint32_t)0xA130FD, 0x06 ); // return banks to original state
-        umd.writeByteTimeFull( (uint32_t)0xA130FF, 0x07 ); // return banks to original state
+        umd.writeByteTime(0xA130FD, 0x06 ); // return banks to original state
+        umd.writeByteTime(0xA130FF, 0x07 ); // return banks to original state
     }
 
     digitalWrite(umd.nLED, HIGH);

--- a/Examples/Interface/Interface.ino
+++ b/Examples/Interface/Interface.ino
@@ -691,9 +691,10 @@ void readByteBlock()
 {
     char *arg;
     bool sramRead = false;
+    bool bankedPCE = false;
     uint32_t address = 0;
     uint16_t smsAddress, blockSize = 0, i;
-    uint8_t data;
+    uint8_t data, bank = 0;
 
     //get the address in the next argument
     arg = SCmd.next();
@@ -711,6 +712,9 @@ void readByteBlock()
         {
             case 's':
                 sramRead = true;
+                break;
+            case 'b':
+                bankedPCE = true;
                 break;
             default:
                 break;
@@ -746,6 +750,73 @@ void readByteBlock()
             }
 
             break;
+        case umd.PC:
+            if(bankedPCE)
+            {
+                uint32_t currAddress;
+
+                bank = 0;
+                currAddress = address;
+                for( i = 0; i < blockSize; i++ )
+                {
+                    // SFII CE Mapper
+                    // Bank switching occurs in banks 0x40-0x7F
+                    // bank 0x40 ia at 0x80000 in linear ROM space
+                    
+                    if(currAddress < 0x080000)
+                        address = currAddress;
+                    else
+                    if(currAddress < 0x100000)
+                    {
+                        if(bank != 1)
+                        {
+                            umd.writeByte((uint32_t)0x001FF0, 0x00);
+                            bank = 1;
+                        }
+                        address = currAddress;
+                    }
+                    else
+                    if(currAddress < 0x180000)
+                    {
+                        if(bank != 2)
+                        {
+                            umd.writeByte((uint32_t)0x001FF1, 0x01);
+                            bank = 2;
+                        }
+                        address = currAddress - 0x80000;
+                    }
+                    else
+                    if(currAddress < 0x200000)
+                    {
+                        if(bank != 3)
+                        {
+                            umd.writeByte((uint32_t)0x001FF2, 0x01);
+                            bank = 3;
+                        }
+                        address = currAddress - 0x100000;
+                    }
+                    else
+                    if(currAddress < 0x280000)
+                    {
+                        if(bank != 4)
+                        {
+                            umd.writeByte((uint32_t)0x001FF3, 0x01);
+                            bank = 4;
+                        }
+                        address = currAddress - 0x180000;
+                    }
+
+                    data = umd.readByte(address, true);
+                    Serial.write((char)(data));
+                    currAddress ++;
+                } 
+            }
+            else
+            {
+                data = umd.readByte(address++, true);
+                Serial.write((char)(data));
+            }
+            break;     
             
         default:
             for( i = 0; i < blockSize; i++ )

--- a/Python/hardware.py
+++ b/Python/hardware.py
@@ -464,6 +464,9 @@ class umd:
                     cmd = "{0} {1} s\r\n".format(readCmd, address)
                 elif( target == "save" ):
                     cmd = "{0} {1} {2} s\r\n".format(readCmd, address, sizeOfRead)
+                # temporary hack for testing SF II on PCE
+                elif( self.cartType == "PCEngine" and endAddress > 0x100000):
+                    cmd = "{0} {1} {2} b\r\n".format(readCmd, address, sizeOfRead)
                 else:
                     cmd = "{0} {1} {2}\r\n".format(readCmd, address, sizeOfRead)
                 
@@ -528,6 +531,9 @@ class umd:
                         cmd = "{0} {1} s\r\n".format(readCmd, address)
                     elif( target == "save" ):
                         cmd = "{0} {1} {2} s\r\n".format(readCmd, address, sizeOfRead)
+                    # temporary hack for testing SF II on PCE
+                    elif( self.cartType == "PCEngine" and endAddress > 0x100000):
+                        cmd = "{0} {1} {2} b\r\n".format(readCmd, address, sizeOfRead)
                     else:
                         cmd = "{0} {1} {2}\r\n".format(readCmd, address, sizeOfRead)
                                                             

--- a/umd.cpp
+++ b/umd.cpp
@@ -646,34 +646,14 @@ uint16_t umd::readWord(uint32_t address)
     return readData;
 }
 
+
 /*******************************************************************//**
  * The writeByteTime function strobes a byte into nTIME region
- * 
- * \warning upper 8 address bits (23..16) are not modified
- **********************************************************************/
-void umd::writeByteTime(uint16_t address, uint8_t data)
-{
-    _latchAddress(address);
-    _setDatabusOutput();
-
-    //put byte on bus
-    DATAOUTL = data;
-    
-    // write to the bus
-    digitalWrite(GEN_nTIME, LOW);
-    delayMicroseconds(1);
-    digitalWrite(GEN_nTIME, HIGH);
- 
-    _setDatabusInput();
-}
-
-/*******************************************************************//**
- * The writeByteTimeFull function strobes a byte into nTIME region
  * while enabling the rest of the regular signals
  * 
  * \warning upper 8 address bits (23..16) are not modified
  **********************************************************************/
-void umd::writeByteTimeFull(uint32_t address, uint8_t data)
+void umd::writeByteTime(uint32_t address, uint8_t data)
 {
     _latchAddress(address);
     _setDatabusOutput();

--- a/umd.h
+++ b/umd.h
@@ -177,15 +177,7 @@ class umd
          * \param data byte
          * \return void
          **********************************************************************/
-        void writeByteTime(uint16_t address, uint8_t data);
-        
-        /*******************************************************************//**
-         * \brief Write a byte to the nTIME region on genesis with full signals
-         * \param address 16bit address
-         * \param data byte
-         * \return void
-         **********************************************************************/
-        void writeByteTimeFull(uint32_t address, uint8_t data);
+        void writeByteTime(uint32_t address, uint8_t data);
         
         /*******************************************************************//**
          * \brief Write a byte to a 16bit address in the nTIME range (Genesis only)


### PR DESCRIPTION
- Unified writeByteTime since the GEN_nLWR works fine in the rest of the cases as expected.

- Can dump the "SFII mapper" on PC Engine, detected when asking for more than 0x100000 bytes, but it works from any offset.

- Maybe platform specific stuff should be moved to it's own class/function. Will have to think about not polluting the general case code with special cases and flags.