### PR TITLE
Force port of UMD device and multi UMD support and fix two minor bugs

### DIFF
--- a/Python/hardware.py
+++ b/Python/hardware.py
@@ -89,9 +89,9 @@ class umd:
 #
 #  Windows/Linux agnostic, searches for the UMD
 ########################################################################
-    def __init__(self, mode):        
+    def __init__(self, mode, port):        
         self.cartType = mode
-        self.connectUMD(mode)
+        self.connectUMD(mode, port)
 
 ########################################################################    
 ## connectUMD
@@ -100,20 +100,24 @@ class umd:
 #  
 #  Retrieve the ROM's manufacturer flash ID
 ########################################################################
-    def connectUMD(self, mode):
+    def connectUMD(self, mode, port):
 
         #print("mode set value = {0}".format(self.modes.get(mode)))
         
         dbPort = ""
-        # enumerate ports
-        if sys.platform.startswith("win"):
-            ports = ["COM%s" % (i + 1) for i in range(256)]
-        elif sys.platform.startswith ("linux"):
-            ports = glob.glob("/dev/tty[A-Za-z]*")
-        elif sys.platform.startswith ("darwin"):
-            ports = glob.glob("/dev/cu*")
+        
+        if port is None:
+            # enumerate ports
+            if sys.platform.startswith("win"):
+                ports = ["COM%s" % (i + 1) for i in range(256)]
+            elif sys.platform.startswith ("linux"):
+                ports = glob.glob("/dev/tty[A-Za-z]*")
+            elif sys.platform.startswith ("darwin"):
+                ports = glob.glob("/dev/cu*")
+            else:
+                raise EnvironmentError("Unsupported platform")
         else:
-            raise EnvironmentError("Unsupported platform")
+            ports = [port]
 
         # test for dumper on port
         for serialport in ports:

--- a/Python/multi.py
+++ b/Python/multi.py
@@ -1,0 +1,173 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+########################################################################
+# \file multi.py
+# \author René Richard
+# \brief This program allows to read and write to various game cartridges 
+#        including: Genesis, Coleco, SMS, PCE - with possibility for 
+#        future expansion.
+######################################################################## 
+# \copyright This file is part of Universal Mega Dumper.
+#
+#   Universal Mega Dumper is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Universal Mega Dumper is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with Universal Mega Dumper.  If not, see <http://www.gnu.org/licenses/>.
+#
+########################################################################
+
+import os
+import sys
+import glob
+import time
+import serial
+import getopt
+import argparse
+import struct
+
+from subprocess import Popen, PIPE
+
+# https://docs.python.org/3/howto/argparse.html
+
+####################################################################################
+## Main
+####################################################################################
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(prog="multi 0.1.0.0")
+    parser.add_argument("--mode", help="Set the cartridge type", choices=["cv", "gen", "sms", "pce", "tg", "snes"], type=str, default="none")
+    
+    readWriteArgs = parser.add_mutually_exclusive_group()
+    readWriteArgs.add_argument("--checksum", help="Calculate ROM checksum", action="store_true")
+   
+    readWriteArgs.add_argument("--rd", 
+                                help="Read from UMD", 
+                                choices=["rom", "save", "bram", "header", "fid", "sfid", "sf", "sflist", "byte", "word", "sbyte", "sword"], 
+                                type=str)
+    
+    readWriteArgs.add_argument("--wr", 
+                                help="Write to UMD", 
+                                choices=["rom", "save", "bram", "sf"], 
+                                type=str)
+    
+    readWriteArgs.add_argument("--clr", 
+                                help="Clear a memory in the UMD", 
+                                choices=["rom", "rom2", "save", "bram", "sf"], 
+                                type=str)
+    
+    parser.add_argument("--addr", 
+                        nargs=1, 
+                        help="Address for current command", 
+                        type=str,
+                        default="0")
+    
+    parser.add_argument("--size", 
+                        nargs=1, 
+                        help="Size in bytes for current command", 
+                        type=str,
+                        default="1")
+    
+    parser.add_argument("--file", 
+                        help="File path for read/write operations", 
+                        type=str, 
+                        default="console")
+                        
+    parser.add_argument("--sfile", 
+                        help="8.3 filename for UMD's serial flash", 
+                        type=str)
+   
+    args = parser.parse_args()
+    
+    multiArgs = [sys.executable, 'umd.py', '--mode', args.mode]
+        
+    # read operations
+    if args.rd:
+    	multiArgs.append("--rd")
+    	multiArgs.append(args.rd)
+    # clear operations - erase various memories
+    elif args.clr:
+    	multiArgs.append("--clr")
+    	multiArgs.append(args.clr)
+    # write operations
+    elif args.wr:
+    	multiArgs.append("--wr")
+    	multiArgs.append(args.wr)
+    # checksum operations
+    elif args.checksum:
+    	multiArgs.append("--checksum")
+    else:
+        parser.print_help()
+        sys.exit()
+    
+    if args.addr is not None:
+        multiArgs.append("--addr")
+        if isinstance(args.addr, list):
+            multiArgs.append(args.addr[0])
+        else:
+            multiArgs.append(args.addr)
+    
+    if args.size is not None:
+        multiArgs.append("--size")
+        if isinstance(args.size, list):
+            multiArgs.append(args.size[0])
+        else:
+            multiArgs.append(args.size)
+    
+    if args.file is not None:
+        multiArgs.append("--file")
+        multiArgs.append(args.file)
+    
+    if args.sfile is not None:
+        multiArgs.append("--sfile")
+        multiArgs.append(args.sfile)
+
+	# the port force argument
+    multiArgs.append("--port")
+
+    # enumerate ports
+    if sys.platform.startswith("win"):
+        ports = ["COM%s" % (i + 1) for i in range(256)]
+    elif sys.platform.startswith ("linux"):
+        ports = glob.glob("/dev/tty[A-Za-z]*")
+    elif sys.platform.startswith ("darwin"):
+        ports = glob.glob("/dev/cu*")
+    else:
+        raise EnvironmentError("Unsupported platform")
+
+    umdCount = 0
+    prclist = list();
+
+    # test for dumper on port
+    for serialport in ports:
+        try:
+            ser = serial.Serial( port = serialport, baudrate = 460800, bytesize = serial.EIGHTBITS, parity = serial.PARITY_NONE, stopbits = serial.STOPBITS_ONE, timeout=0.1)
+            ser.write(bytes("flash\r\n","utf-8"))
+            response = ser.readline().decode("utf-8")
+            if response == "thunder\r\n":
+                #print(serialport)
+                ser.close()
+                newMultiArgs = list(multiArgs)
+                newMultiArgs.append(serialport)
+                prc = Popen(newMultiArgs) #, stdout=STDOUT, stderr=STDOUT)
+                prclist.append(prc)
+                umdCount += 1
+            else:
+                ser.close()
+        except (OSError, serial.SerialException):
+            pass
+
+	# wait for all the UMD's to complete
+    for prci in prclist:
+        while prci.poll() is None:
+            #print(".")
+            time.sleep(1)
+    
+    print("Multi UMD Complete!")

--- a/Python/umd.py
+++ b/Python/umd.py
@@ -116,17 +116,21 @@ if __name__ == "__main__":
     parser.add_argument("--sfile", 
                         help="8.3 filename for UMD's serial flash", 
                         type=str)
+
+    parser.add_argument("--port", 
+                        help="Serial port name of UMD", 
+                        type=str)
     
     args = parser.parse_args()
     
     # init UMD object, set console type
     cartType = carts.get(args.mode)
-    #umd = umd(cartType)
+    #umd = umd(cartType, args.port)
     
     #if( args.mode != "none" ):
         ##print( "setting mode to {0}".format(carts.get(args.mode)) )
         #if( not(args.checksum & ( args.file != "console") ) ):
-            #umd.connectUMD(cartType)
+            #umd.connectUMD(cartType, args.port)
     
     #figure out the size of the operation, default to 1 in arguments so OK to calc everytime
     if( args.size[0].endswith("Kb") ):  
@@ -149,7 +153,7 @@ if __name__ == "__main__":
         
         # get the file list from the UMD's serial flash
         if args.rd == "sflist":
-            umd = umd(cartType)
+            umd = umd(cartType, args.port)
             umd.sfGetFileList()
             usedSpace = 0
             freeSpace = 0
@@ -168,7 +172,7 @@ if __name__ == "__main__":
             if ( args.file == "console" ):
                 print("must specify a local --FILE to write the serial flash file's contents into")
             else:
-                umd = umd(cartType)
+                umd = umd(cartType, args.port)
                 umd.sfReadFile(args.sffile, args.file)
                 print("read {0} from serial flash to {1} in {2:.3f} s".format(args.sfile, args.file, umd.opTime))
         
@@ -181,7 +185,7 @@ if __name__ == "__main__":
                 if args.file != "console":
                     extractHeader(genesis.headerAddress, genesis.headerSize, args.file, "_header.bin")
                 else:
-                    umd = umd(cartType)
+                    umd = umd(cartType, args.port)
                     umd.read(genesis.headerAddress, genesis.headerSize, args.rd, "_header.bin")
                 # display
                 for item in sorted( genesis.formatHeader("_header.bin").items() ):
@@ -200,7 +204,7 @@ if __name__ == "__main__":
                 if args.file != "console":
                     extractHeader(sms.headerAddress, sms.headerSize, args.file, "_header.bin")
                 else:
-                    umd = umd(cartType)
+                    umd = umd(cartType, args.port)
                     umd.read(sms.headerAddress, sms.headerSize, args.rd, "_header.bin")
                     
                 for item in sorted( sms.formatHeader("_header.bin").items() ):
@@ -224,20 +228,20 @@ if __name__ == "__main__":
                 
         # read the flash id - obviously does not work on original games with OTP roms
         elif args.rd == "fid":
-            umd = umd(cartType)
+            umd = umd(cartType, args.port)
             umd.getFlashID()
             for item in sorted( umd.flashIDData.items() ):
                 print(item)
             
         # read the serial flash id
         elif args.rd == "sfid":
-            umd = umd(cartType)
+            umd = umd(cartType, args.port)
             umd.sfGetId()
             print (''.join('0x{:02X} '.format(x) for x in umd.sfID))
                 
         # read from the cartridge, ROM/SAVE/BRAM specified in args.rd
         else:
-            umd = umd(cartType)
+            umd = umd(cartType, args.port)
             print("reading {0} bytes starting at address 0x{1:X} from {2} {3}".format(byteCount, address, cartType, args.rd))
             umd.read(address, byteCount, args.rd, args.file)
             print("read {0} bytes completed in {1:.3f} s".format(byteCount, umd.opTime))
@@ -245,7 +249,7 @@ if __name__ == "__main__":
     # clear operations - erase various memories
     elif args.clr:
         # currently always need the hardware for clear
-        umd = umd(cartType)
+        umd = umd(cartType, args.port)
         
         # erase the entire serial flash
         if args.clr == "sf":
@@ -275,7 +279,7 @@ if __name__ == "__main__":
     # write operations
     elif args.wr:
         # currently always need the hardware for writes
-        umd = umd(cartType)
+        umd = umd(cartType, args.port)
         
         # write a local file to the UMD's serial flash
         if args.wr == "sf":
@@ -319,7 +323,7 @@ if __name__ == "__main__":
                 
             else:
                 #  read rom size from header
-                umd = umd(cartType)
+                umd = umd(cartType, args.port)
                 umd.read(genesis.headerAddress, genesis.headerSize, args.rd, "_header.bin")
                 romSize = genesis.formatHeader("_header.bin").get("ROM End")[0] + 1
                 print("Found ROM size = {} bytes in cartridge header, reading in...".format(romSize))
@@ -350,7 +354,7 @@ if __name__ == "__main__":
                 
             else:
                 #  read rom size from header
-                umd = umd(cartType)
+                umd = umd(cartType, args.port)
                 umd.read(sms.headerAddress, sms.headerSize, args.rd, "_header.bin")
                 romSize = sms.formatHeader("_header.bin").get("Size")
                 print("Found ROM size = {} bytes in cartridge header, reading in...".format(romSize))

--- a/Python/umd.py
+++ b/Python/umd.py
@@ -378,7 +378,7 @@ if __name__ == "__main__":
     elif args.byteswap:
         startTime = time.time()
         genesis = genesis()
-        gensis.byteSwap(args.byteswap[0], args.file)
+        genesis.byteSwap(args.byteswap[0], args.file)
         opTime = time.time() - startTime
         del genesis
     else:

--- a/umdbase.cpp
+++ b/umdbase.cpp
@@ -83,7 +83,7 @@ void umdbase::setup()
     pinMode(nRD, OUTPUT);
     digitalWrite(nRD, HIGH);
     pinMode(nCE, OUTPUT);
-    digitalWrite(nRD, HIGH)
+    digitalWrite(nRD, HIGH);
     
     //cartridge detect
     pinMode(nCART, INPUT_PULLUP);


### PR DESCRIPTION
Add argument to force the port of the UMD device.
Added multi.py script to use multiple UMD devices in parallel.

Missing a semi-colon for compilation umdbase.cpp, tiny fix.
Variable typo in umd.py, tiny fix.